### PR TITLE
Add branch version extraction and set target_milestone on bug resolve

### DIFF
--- a/helpers/github_responce_object.rb
+++ b/helpers/github_responce_object.rb
@@ -4,6 +4,10 @@ require_relative 'github_objects/repository'
 require_relative 'github_objects/commit'
 # Class for working with GitHubResponce objects
 class GithubResponceObjects
+  # @return [Regexp] regexp for extracting version from branch name
+  VERSION_REGEXP = /v?(\d+\.\d+[\.\d]*)/
+  # @return [String] default version for branches without a version number
+  DEFAULT_VERSION = '99.99'
   # @return [Repository] repository data
   attr_reader :repository
   # @return [String] branch name
@@ -16,5 +20,16 @@ class GithubResponceObjects
     @repository = Repository.new(params['repository'])
     @branch = params['ref'] if params['ref']
     @commits = params['commits'].map { |commit| Commit.new(commit) } if params['commits']
+  end
+
+  # Extract version from branch name
+  # @example "refs/heads/hotfix/v9.4.1" => "9.4.1"
+  # @example "refs/heads/develop" => "99.99"
+  # @return [String] version string or DEFAULT_VERSION if not found
+  def branch_version
+    return DEFAULT_VERSION unless @branch
+
+    match = @branch.match(VERSION_REGEXP)
+    match ? match[1] : DEFAULT_VERSION
   end
 end

--- a/helpers/hook_detection.rb
+++ b/helpers/hook_detection.rb
@@ -20,7 +20,9 @@ class HookDetection
         result[commit.id] << { commit_message: commit.message,
                                comment: create_full_comment(commit, @object.branch),
                                bug_id: commit.bug_id,
-                               action: current_pattern[:action] }
+                               action: current_pattern[:action],
+                               branch: @object.branch,
+                               branch_version: @object.branch_version }
       end
     end
     result

--- a/lib/testing-github-warden/executioner/executioner_helper.rb
+++ b/lib/testing-github-warden/executioner/executioner_helper.rb
@@ -6,12 +6,13 @@ module ExecutionerHelper
     @logger.info ">> Add RESOLVED/FIXED to bug #{action_data['bug_id']}"
     return unless change_status?(action_data)
 
+    update_params = { status: 'RESOLVED', resolution: 'FIXED' }
+    update_params[:target_milestone] = action_data['branch_version'] if action_data['branch_version']
+
     responce = {}
     5.times do |i|
       @logger.info ">> Add(#{i + 1}) RESOLVED/FIXED to bug #{action_data['bug_id']}"
-      responce = @bugzilla.update_bug(action_data['bug_id'],
-                                      status: 'RESOLVED',
-                                      resolution: 'FIXED')
+      responce = @bugzilla.update_bug(action_data['bug_id'], **update_params)
       @logger.info "Bugzilla responce #{responce.body}"
 
       break unless responce['error']

--- a/spec/unit/github_responce_objects_spec.rb
+++ b/spec/unit/github_responce_objects_spec.rb
@@ -22,6 +22,47 @@ describe GithubResponceObjects do
     end
   end
 
+  describe 'branch_version' do
+    it 'returns default version for develop branch' do
+      expect(github_object.branch_version).to eq('99.99')
+    end
+
+    it 'extracts version from hotfix branch' do
+      commit = Fixtures.commit
+      commit['ref'] = 'refs/heads/hotfix/v9.4.1'
+      github_object = described_class.new(commit)
+      expect(github_object.branch_version).to eq('9.4.1')
+    end
+
+    it 'extracts version from release branch' do
+      commit = Fixtures.commit
+      commit['ref'] = 'refs/heads/release/v9.5.0'
+      github_object = described_class.new(commit)
+      expect(github_object.branch_version).to eq('9.5.0')
+    end
+
+    it 'extracts version without v prefix' do
+      commit = Fixtures.commit
+      commit['ref'] = 'refs/heads/hotfix/9.4.1'
+      github_object = described_class.new(commit)
+      expect(github_object.branch_version).to eq('9.4.1')
+    end
+
+    it 'returns default version for master branch' do
+      commit = Fixtures.commit
+      commit['ref'] = 'refs/heads/master'
+      github_object = described_class.new(commit)
+      expect(github_object.branch_version).to eq('99.99')
+    end
+
+    it 'returns default version when branch is nil' do
+      commit = Fixtures.commit
+      commit['ref'] = nil
+      github_object = described_class.new(commit)
+      expect(github_object.branch_version).to eq('99.99')
+    end
+  end
+
   describe 'commits' do
     it 'github_object.commits should be an array' do
       expect(github_object.commits).to be_a(Array)


### PR DESCRIPTION
Extract version from branch name (e.g. refs/heads/hotfix/v9.4.1 → 9.4.1) and pass it through the action pipeline. When resolving a bug as FIXED, also set target_milestone to the branch version. Branches without a version (develop, master) default to 99.99.