### PR TITLE
Fix branch version to strip trailing .0 patch for Bugzilla format

### DIFF
--- a/helpers/github_responce_object.rb
+++ b/helpers/github_responce_object.rb
@@ -23,13 +23,18 @@ class GithubResponceObjects
   end
 
   # Extract version from branch name
+  # Strips trailing .0 patch to match Bugzilla version format
+  # @example "refs/heads/hotfix/v9.4.0" => "9.4"
   # @example "refs/heads/hotfix/v9.4.1" => "9.4.1"
+  # @example "refs/heads/hotfix/v10.0.0" => "10.0"
   # @example "refs/heads/develop" => "99.99"
   # @return [String] version string or DEFAULT_VERSION if not found
   def branch_version
     return DEFAULT_VERSION unless @branch
 
     match = @branch.match(VERSION_REGEXP)
-    match ? match[1] : DEFAULT_VERSION
+    return DEFAULT_VERSION unless match
+
+    match[1].sub(/\.0$/, '')
   end
 end

--- a/spec/unit/github_responce_objects_spec.rb
+++ b/spec/unit/github_responce_objects_spec.rb
@@ -34,11 +34,18 @@ describe GithubResponceObjects do
       expect(github_object.branch_version).to eq('9.4.1')
     end
 
-    it 'extracts version from release branch' do
+    it 'strips trailing .0 patch from version' do
       commit = Fixtures.commit
       commit['ref'] = 'refs/heads/release/v9.5.0'
       github_object = described_class.new(commit)
-      expect(github_object.branch_version).to eq('9.5.0')
+      expect(github_object.branch_version).to eq('9.5')
+    end
+
+    it 'strips trailing .0 patch for 10.0.0' do
+      commit = Fixtures.commit
+      commit['ref'] = 'refs/heads/hotfix/v10.0.0'
+      github_object = described_class.new(commit)
+      expect(github_object.branch_version).to eq('10.0')
     end
 
     it 'extracts version without v prefix' do


### PR DESCRIPTION
Bugzilla uses "9.4" not "9.4.0" for .0 patch versions. Strip the trailing .0 so versions like v9.4.0 → 9.4, v10.0.0 → 10.0, while non-zero patches like v9.4.1 remain 9.4.1.